### PR TITLE
We cant assume that consumers will be using implicit usings i added them explicit now.

### DIFF
--- a/SharedContext/Dao/CacheHandler.cs
+++ b/SharedContext/Dao/CacheHandler.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using System;
 using System.Runtime.Caching;
 
 namespace SharedContext.Dao;

--- a/SharedContext/Dao/DataverseAccessObject_Associate.cs
+++ b/SharedContext/Dao/DataverseAccessObject_Associate.cs
@@ -10,6 +10,8 @@ using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Metadata;
 using Microsoft.Xrm.Sdk.Query;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace SharedContext.Dao;
 

--- a/SharedContext/Dao/DataverseAccessObject_Bulk.cs
+++ b/SharedContext/Dao/DataverseAccessObject_Bulk.cs
@@ -10,6 +10,8 @@ using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Metadata;
 using Microsoft.Xrm.Sdk.Query;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace SharedContext.Dao;
 

--- a/SharedContext/Dao/DataverseAccessObject_OptionSet.cs
+++ b/SharedContext/Dao/DataverseAccessObject_OptionSet.cs
@@ -10,6 +10,7 @@ using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Metadata;
 using Microsoft.Xrm.Sdk.Query;
+using System.Linq;
 
 namespace SharedContext.Dao;
 

--- a/SharedContext/Dao/DataverseAccessObject_Retrieve.cs
+++ b/SharedContext/Dao/DataverseAccessObject_Retrieve.cs
@@ -10,6 +10,8 @@ using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Metadata;
 using Microsoft.Xrm.Sdk.Query;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace SharedContext.Dao;
 

--- a/SharedContext/Dao/DataverseAccessObject_Retrieve_Cachable.cs
+++ b/SharedContext/Dao/DataverseAccessObject_Retrieve_Cachable.cs
@@ -10,6 +10,7 @@ using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Metadata;
 using Microsoft.Xrm.Sdk.Query;
+using System.Collections.Generic;
 
 namespace SharedContext.Dao;
 

--- a/SharedContext/Dao/DataverseStaticExtensions.cs
+++ b/SharedContext/Dao/DataverseStaticExtensions.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;

--- a/SharedContext/Dao/DataverseWrapAccess.cs
+++ b/SharedContext/Dao/DataverseWrapAccess.cs
@@ -4,6 +4,8 @@ using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Query;
 using System.Diagnostics;
 using System.ServiceModel;
+using System;
+using System.Collections.Generic;
 
 namespace SharedContext.Dao;
 

--- a/SharedContext/Dao/Exceptions/DataverseInteractionException.cs
+++ b/SharedContext/Dao/Exceptions/DataverseInteractionException.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace SharedContext.Dao.Exceptions;
 
 #pragma warning disable CA2237 // Mark ISerializable types with serializable

--- a/SharedContext/Dao/IDataverseAccessObject.cs
+++ b/SharedContext/Dao/IDataverseAccessObject.cs
@@ -3,6 +3,8 @@ using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Query;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
+using System.Collections.Generic;
+using System;
 
 namespace SharedContext.Dao;
 


### PR DESCRIPTION
I am working on a nuget package and i dont typically use implicit usings. I think that the Dao files should have explicit using as that would work for both parts that are using it.


