### PR TITLE
Update Directory.Build.props - Remove space in Import tag

### DIFF
--- a/src/Tools/Directory.Build.props
+++ b/src/Tools/Directory.Build.props
@@ -6,7 +6,7 @@
   the auto imported Directory.Build.props
   -->
   <Import
-    Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
+    Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..,Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup Label="Build instructions">
     <OutputType>Library</OutputType>


### PR DESCRIPTION
Removed space in src/Tools/Directory.Build.props. Inside the Import tag, the directive Project=... ,_ Directory.Build.props .... caused initial load errors in Visual Studio similar to this error:

https://github.com/dotnet/runtime/issues/69392