### PR TITLE
Fix cross-platform build and .NET 10 compatibility

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -513,6 +513,7 @@ dotnet_diagnostic.S1135.severity = suggestion       # https://github.com/atc-net
 dotnet_diagnostic.CA1308.severity = none	# General ignore, this rule seems broken, we do sometimes need to lowercase stuff! And upper-case is somewhat different...
 dotnet_diagnostic.CA1515.severity = none	# In believing this rule to be a bit too eager - we do need the public over internal classes at some points (correct this if it's wrong)
 dotnet_diagnostic.CA1848.severity = none	# Use the LoggerMessage delegates for high performance logging scenarios
+dotnet_diagnostic.CA1873.severity = none	# Evaluation of this argument may be expensive - same reasoning as CA1848
 dotnet_diagnostic.CA1860.severity = none	# We will accept the use of .Any()
 dotnet_diagnostic.CA2254.severity = none	# We should not log so much that this potential performance optimization will have any effect
 dotnet_diagnostic.SA1208.severity = none	# Ordering of System usings before other usings. This conflicts with the built-in tool in VS to auto-remove unused usings and order the rest on each save of a file

--- a/src/Dataverse/Plugins/Plugins.csproj
+++ b/src/Dataverse/Plugins/Plugins.csproj
@@ -40,7 +40,7 @@
 	</ItemGroup>
 	
 	<!-- ILRepack is only need because DAXIF doesn't support Plugin Packages yet -->
-	<Target Name="ILRepack" AfterTargets="Build">
+	<Target Name="ILRepack" AfterTargets="Build" Condition="$([MSBuild]::IsOSPlatform('Windows'))">
 		<ItemGroup>
 			<InputAssemblies Include="$(TargetPath)" />
 			<InputAssemblies Include="$(TargetDir)Microsoft.Bcl.AsyncInterfaces.dll" />
@@ -53,7 +53,7 @@
 		</ItemGroup>
 		<Exec Command="$(PkgILRepack)\tools\ILRepack.exe /parallel /keyfile:..\..\..\xrmbedrock.snk /lib:$(TargetDir) /out:$(TargetDir)ILMerged.$(TargetFileName) @(InputAssemblies -> '%(Identity)', ' ')" />
   </Target>
-	<Target Name="SignDLL" AfterTargets="ILRepack">
+	<Target Name="SignDLL" AfterTargets="ILRepack" Condition="$([MSBuild]::IsOSPlatform('Windows'))">
 	  <Exec Command="signtool sign /p someRandomPassword /f ..\..\..\plugincert.pfx /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 &quot;$(TargetDir)ILMerged.$(TargetFileName)&quot;" />
 	</Target>
 	<Import Project="..\SharedPluginLogic\SharedPluginLogic.projitems" Label="Shared" />

--- a/test/IntegrationTests/XrmMockupFixture.cs
+++ b/test/IntegrationTests/XrmMockupFixture.cs
@@ -26,7 +26,7 @@ public class XrmMockupFixture
                     BaseCustomApiTypes = new Tuple<string, Type>[] { new("demo", typeof(CustomAPI)) },
                     EnableProxyTypes = true,
                     IncludeAllWorkflows = false,
-                    MetadataDirectoryPath = "..\\..\\..\\..\\SharedTest\\MetadataGenerated",
+                    MetadataDirectoryPath = Path.Combine("..", "..", "..", "..", "SharedTest", "MetadataGenerated"),
                 };
             }
         }


### PR DESCRIPTION
- Add OS condition to ILRepack/SignDLL targets so Plugins project builds on macOS
- Use Path.Combine for MetadataDirectoryPath to fix test discovery on non-Windows
- Suppress CA1873 analyzer rule (same reasoning as existing CA1848 suppression)