### PR TITLE
README line continuation stance? and parameter name fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,16 @@ Additionally install [PowerShell Core](https://github.com/PowerShell/PowerShell)
 2. Create a new project, replacing each placeholder value with your own:
 
    ```bash
-   dotnet new xrmbedrock -n MyProject \
-     --company-name MyOrg \
-     --publisher-prefix abc \
-     --solution-id mysol \
-     --dev-url https://myorg-dev.crm4.dynamics.com \
-     --test-url https://myorg-test.crm4.dynamics.com \
-     --uat-url https://myorg-uat.crm4.dynamics.com \
-     --prod-url https://myorg-prod.crm4.dynamics.com \
-     --rg-name myorg-mysol \
-     --cert-password MySecurePassword123 \
+   dotnet new xrmbedrock -n MyProject `
+     --company-name MyOrg `
+     --publisher-prefix abc `
+     --solution mysol `
+     --dev-url https://myorg-dev.crm4.dynamics.com `
+     --test-url https://myorg-test.crm4.dynamics.com `
+     --uat-url https://myorg-uat.crm4.dynamics.com `
+     --prod-url https://myorg-prod.crm4.dynamics.com `
+     --rg-name myorg-mysol `
+     --cert-password MySecurePassword123 `
      --username user@myorg.onmicrosoft.com
    ```
 


### PR DESCRIPTION
Replace bash-style `\` line continuations with PowerShell backticks (`)?

And rename `--solution-id` to `--solution` to match the actual template parameter.

It's possible it's better to use another approach than the command in readme and having a file or just have two "copy-paste" sections or just a note in the top, (use "\"on linux+mac, use (') on powershell. 
But "\" don't work on powershell, as that ain't the line continuation there. 