### PR TITLE
Rename plugin DLL prefix: ILMerged. -> Merged.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To produce the deployable, merged and signed DLL, opt in with the `PackAndSignPl
 dotnet build src/Dataverse/Plugins/Plugins.csproj -c Release -p:PackAndSignPlugin=true
 ```
 
-**Caveat:** the Daxif deploy scripts expect `ILMerged.templatecompanyname.templateprojectname.Dataverse.Plugins.dll`, which is produced **only** when `-p:PackAndSignPlugin=true` is passed. A plain build does not produce it, so build with the flag before deploying the plugin locally. The pipeline already passes this flag, so CI output is unchanged.
+**Caveat:** the Daxif deploy scripts expect `Merged.templatecompanyname.templateprojectname.Dataverse.Plugins.dll`, which is produced **only** when `-p:PackAndSignPlugin=true` is passed. A plain build does not produce it, so build with the flag before deploying the plugin locally. The pipeline already passes this flag, so CI output is unchanged.
 
 # Quick start (dotnet new)
 

--- a/src/Dataverse/Plugins/Plugins.csproj
+++ b/src/Dataverse/Plugins/Plugins.csproj
@@ -51,10 +51,10 @@
 			<InputAssemblies Include="$(TargetDir)System.Threading.Tasks.Extensions.dll" />
 			<InputAssemblies Include="$(TargetDir)System.Text.Json.dll" />
 		</ItemGroup>
-		<Exec Command="$(PkgILRepack)\tools\ILRepack.exe /parallel /keyfile:..\..\..\templatecompanyname.snk /lib:$(TargetDir) /out:$(TargetDir)ILMerged.$(TargetFileName) @(InputAssemblies -> '%(Identity)', ' ')" />
+		<Exec Command="$(PkgILRepack)\tools\ILRepack.exe /parallel /keyfile:..\..\..\templatecompanyname.snk /lib:$(TargetDir) /out:$(TargetDir)Merged.$(TargetFileName) @(InputAssemblies -> '%(Identity)', ' ')" />
   </Target>
 	<Target Name="SignDLL" AfterTargets="ILRepack" Condition="'$(PackAndSignPlugin)' == 'true'">
-	  <Exec Command="signtool sign /p templatecertpassword /f ..\..\..\plugincert.pfx /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 &quot;$(TargetDir)ILMerged.$(TargetFileName)&quot;" />
+	  <Exec Command="signtool sign /p templatecertpassword /f ..\..\..\plugincert.pfx /tr http://timestamp.digicert.com /fd SHA256 /td SHA256 &quot;$(TargetDir)Merged.$(TargetFileName)&quot;" />
 	</Target>
 	<Import Project="..\SharedPluginLogic\SharedPluginLogic.projitems" Label="Shared" />
 	<Import Project="..\..\Shared\SharedContext\SharedContext.projitems" Label="Shared" />

--- a/src/Tools/Daxif/_Config.fsx
+++ b/src/Tools/Daxif/_Config.fsx
@@ -99,7 +99,7 @@ module Path =
   let webResourceProject = srcRoot ++ "Dataverse" ++ @"WebResources"
   let webResourceFolder = webResourceProject ++ @"src" ++ (sprintf "%s_%s" PublisherInfo.prefix SolutionInfo.name)
   
-  let pluginDllName = "ILMerged.templatecompanyname.templateprojectname.Dataverse.Plugins"
+  let pluginDllName = "Merged.templatecompanyname.templateprojectname.Dataverse.Plugins"
 
   /// Path information used by the SolutionPackager scripts
   module SolutionPack =


### PR DESCRIPTION
## What
Rename the plugin DLL prefix `ILMerged.` → `Merged.` (4 references, 3 files: `Plugins.csproj` ×2, `_Config.fsx`, `README.md`). All must match — the csproj output filename is the assembly name Daxif's plugin sync looks for.

## Why
The build uses ILRepack, not the old ILMerge tool — `ILMerged.` is a stale leftover. `Merged.` describes the artifact, not the tool.

## Verified
Built the signed `Merged.*.dll` and ran Daxif plugin sync against a dev environment — the assembly registered and plugins executed under the new name. No `ILMerged` remains in the repo.

## Alternatives
`Merged.` (chosen) · `Bundled.` · `Packed.` (mirrors the `PackAndSignPlugin` flag) · `ILRepacked.` (accurate but tool-named again).
